### PR TITLE
enforce standard locale when parsing pacman output

### DIFF
--- a/bin/p3wm
+++ b/bin/p3wm
@@ -78,7 +78,7 @@ get_ver_tuple() {
 }
 
 get_pkg_arch() {
-  pacman -Qi "$1" | awk '$1 == "Architecture" {print $3}'
+  LANG=C pacman -Qi "$1" | awk '$1 == "Architecture" {print $3}'
 }
 
 resolve_tool() {


### PR DESCRIPTION
enforce standard locale when parsing pacman output, otherwise localized messages can make it fail

while it doesn't fix every potential source of bug #1 , at least it does for my use case