### PR TITLE
ci(lint): pin `differential-shellcheck` to `v3` tag

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -12,10 +12,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
-    permissions:
-      security-events: write
-      pull-requests: write
-
     steps:
       - name: Repository checkout
         uses: actions/checkout@v3
@@ -23,6 +19,6 @@ jobs:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@latest
+        uses: redhat-plumbers-in-action/differential-shellcheck@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Please consider using the `v3` tag instead of `latest`. We expect that a new major release could break the API of the `differential-shellcheck` GitHub Action. I have also removed write permissions since they are required only for private repositories.

Related to:

- https://github.com/redhat-plumbers-in-action/differential-shellcheck/pull/156